### PR TITLE
HOTT-2126: Support CC in cds emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ REGION="eu-west-2" # Simple Email Service region we send from
 FROM_EMAIL="Online Trade Tariff Support <trade-tariff-support@transformuk.com>" # The from email address used when sending out the daily update files
 SEND_MAIL=1 # Whether or not to email stakeholders - 0 for off, 1 for on
 TO_EMAILS="Matthew Lavis <matt.lavis@digital.hmrc.gov.uk>,William Fish <william.fish@digital.hmrc.gov.uk>"
+CC_EMAILS="William Fish <william.fish@digital.hmrc.gov.uk>"
 
 # CDS file downloading configuration
 CLIENT_ID="<username>" # The id used for authenticating when downloading CDS zip files
@@ -19,3 +20,4 @@ OTT_HOST="https://www.trade-tariff.service.gov.uk" # The Online Trade Tariff hos
 # Additional configuration
 OVERWRITE_XLSX="0" # Forces rewrites of existing XLSX change files
 IMPORT_FOLDER="tmp/import/" # A temporary directory where we store data
+

--- a/classes/ses_mailer.py
+++ b/classes/ses_mailer.py
@@ -30,6 +30,7 @@ class SesMailer(object):
         self._attachments = attachments
         self._client = boto3.client("ses", region_name=os.getenv("AWS_REGION"))
         self._to_emails = os.getenv("TO_EMAILS", default="")
+        self._cc_emails = os.getenv("CC_EMAILS", default="")
         self._from_email = os.getenv("FROM_EMAIL", default="")
         self._content = content
 
@@ -38,6 +39,7 @@ class SesMailer(object):
         message["Subject"] = self._subject
         message["From"] = self._from_email
         message["To"] = self._to_emails
+        message["CC"] = self._cc_emails
         body = MIMEText(self._content, "html")
         message.attach(body)
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2126

### What?

I have added/removed/altered:

- [x] Added support for carbon copy destination addresses
- [x] Updated .env.example to highlight configurable CC_EMAILS

### Why?

I am doing this because:

- I'm adding this to declutter the cds email to line and to reflect who the main stakeholders are