### PR TITLE
Remove successful run slack message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,6 @@ jobs:
           command: |
             aws s3 sync resources/ s3://$REPORTING_BUCKET_NAME/changes/uk/
       - slack/notify:
-          channel: tariffs-etl
-          event: pass
-          template: basic_success_1
-      - slack/notify:
           channel: deployments
           event: fail
           template: basic_fail_1


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removed slack notification on successful circle run

### Why?

I am doing this because:

- This is just noise
