### PR TITLE
HOTT-2179: Adds exponential retries when pulling reference data

### DIFF
--- a/classes/reference_data.py
+++ b/classes/reference_data.py
@@ -30,18 +30,20 @@ class ReferenceDataHandler(object):
             return response_json["data"]
 
     def retry_with_backoff(self, function, retries=5, backoff_in_seconds=1):
-        x = 0
+        number_of_retries = 0
         while True:
             try:
                 return function()
             except Exception:
-                if x == retries:
+                if number_of_retries == retries:
                     print("Failed to download reference data", self._url)
                     sys.exit(1)
 
-                sleep = backoff_in_seconds * 2**x + random.uniform(0, 1)
+                sleep = backoff_in_seconds * 2**number_of_retries + random.uniform(
+                    0, 1
+                )
                 time.sleep(sleep)
-                x += 1
+                number_of_retries += 1
 
 
 class GeographyList(object):

--- a/classes/reference_data.py
+++ b/classes/reference_data.py
@@ -29,11 +29,10 @@ class ReferenceDataHandler(object):
         else:
             return response_json["data"]
 
-    def retry_with_backoff(self, function, retries=5, backoff_in_seconds=1):
-        number_of_retries = 0
-        while True:
+    def retry_with_backoff(self, callback, retries=5, backoff_in_seconds=1):
+        for number_of_retries in range(1, retries + 1):
             try:
-                return function()
+                return callback()
             except Exception:
                 if number_of_retries == retries:
                     print("Failed to download reference data", self._url)
@@ -43,7 +42,6 @@ class ReferenceDataHandler(object):
                     0, 1
                 )
                 time.sleep(sleep)
-                number_of_retries += 1
 
 
 class GeographyList(object):


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2179

### What?

I have added/removed/altered:

- [x] Added exponential backoff/retry when pulling reference data

### Why?

I am doing this because:

- We are getting failures due to service availability at peak times that could be retried (are typically retried in the frontend)
- This should make the cds file pipeline more robust
