### PR TITLE
HOTT-2730: Adds handling for references to expired geographical areas

### DIFF
--- a/cds_objects/geographical_area_membership.py
+++ b/cds_objects/geographical_area_membership.py
@@ -49,4 +49,11 @@ class GeographicalAreaMembership(Master):
             )
 
     def get_member_description(self):
-        self.member_description = g.geography_hjid_dict[self.hjid_of_member]
+        if self.hjid_of_member in g.geography_hjid_dict:
+            self.member_description = g.geography_hjid_dict[self.hjid_of_member]
+        else:
+            self.member_description = (
+                "HJID "
+                + str(self.hjid_of_member)
+                + " not found. Is this an expired geographical area?"
+            )


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2730

### What?

I have added/removed/altered:

- [x] Added handling when pulling out descriptions for expired geographical areas

### Why?

I am doing this because:

- This is driven by a failure in the email changes workflow where hjids are being referenced that aren't being returned in the response. The issue is that these areas do not exist/have not existed since 2002/2000.

```sql
 geographical_area_sid | geographical_area_id | hjid  |  validity_end_date
-----------------------+----------------------+-------+---------------------
                   248 | TP                   | 23551 | 2002-12-31 00:00:00
                   186 | XR                   | 23845 | 2000-12-31 00:00:00
```

- We want to make sure that the relevant stakeholders know that there is an issue with this particular file and membership
