### PR TITLE
HMRC-1378: Remove caching of unpinned dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   IAM_ROLE_ARN: arn:aws:iam::382373577178:role/GithubActions-CDS-Downloader-File-Role
   REPORTING_BUCKET_NAME: trade-tariff-reporting-382373577178
   SECRET_NAME: download-cds-files-configuration
+  PYTHON_VERSION: '3'
 
 jobs:
   lint:
@@ -22,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - uses: actions/cache@v4
         with:
@@ -46,15 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          key: deps-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.in') }}
-          path: |
-            ~/.cache/pip
-            venv
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/weekday.yml
+++ b/.github/workflows/weekday.yml
@@ -14,6 +14,7 @@ env:
   IAM_ROLE_ARN: arn:aws:iam::382373577178:role/GithubActions-CDS-Downloader-File-Role
   REPORTING_BUCKET_NAME: trade-tariff-reporting-382373577178
   SECRET_NAME: download-cds-files-configuration
+  PYTHON_VERSION: '3'
 
 jobs:
   email_changes:
@@ -25,15 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        key: deps-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements.in') }}
-        path: |
-          ~/.cache/pip
-          venv
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install system dependencies
       run: |


### PR DESCRIPTION
### Jira link

[HMRC-1378](https://transformuk.atlassian.net/browse/HMRC-1378)

### What?

I have added/removed/altered:

- [x] Removed caching from both workflows

### Why?

I am doing this because:

- We don't want a cache key that includes requirements.txt since this doesn't exist in the repo
- We don't want a cache key against requirements.in since this doesn't pin to versions of dependencies and the cache will quickly be stale
- We don't want to cache venv since the python version is loose to the patch version (which is actually something we want)
- We essentially made a trade off by not pinning specific dependencies/making updates dynamic and lost the ability to benefit from caching

### AC

I can consider this piece of work done, when:

- Workflows now pass
